### PR TITLE
Use drafter instead of snowcrash

### DIFF
--- a/APIBlueprint.py
+++ b/APIBlueprint.py
@@ -57,7 +57,7 @@ class ParseYamlAstCommand(TextCommand):
     args = opt
     
     source = Text.all(self.view)
-    result = run_command ("snowcrash", args=args, source=source)
+    result = run_command ("drafter", args=args, source=source)
 
     body = result["err"] + '\n' + result["out"]
 
@@ -76,7 +76,7 @@ class ParseJsonAstCommand(TextCommand):
     args = opt
     
     source = Text.all(self.view)
-    result = run_command ("snowcrash", args=args, source=source)
+    result = run_command ("drafter", args=args, source=source)
     body = result["err"] + '\n' + result["out"]
 
     output = self.view.window().new_file()

--- a/APIBlueprint.sublime-settings
+++ b/APIBlueprint.sublime-settings
@@ -1,6 +1,6 @@
 {
   /*
-    The directory containing your snowcrash binary. Usually
+    The directory containing your drafter binary. Usually
     /usr/local/bin.
   */
   "binDir": "/usr/local/bin"

--- a/README.md
+++ b/README.md
@@ -2,22 +2,23 @@
 This is the official [API Blueprint](http://apiblueprint.org/) plugin for [Sublime Text](http://www.sublimetext.com) with following features:
 
 - Syntax highlighting for the `API Blueprint` format
-- Compiling blueprint into its [AST media-type](https://github.com/apiaryio/snowcrash/wiki/API-Blueprint-AST-Media-Types)
+- Compiling blueprint into its [AST media-type](https://github.com/apiaryio/api-blueprint-ast#ast-description)
 - Live linting of blueprints as you type using `SublimeLinter3`
 
 This plug-in works both with **Sublime Text 2 and 3**. However linting is supported on Sublime Text 3 only.
 
 ## Requirements
-### Snow Crash
-In order for this plugin to work properly you need to have the API Blueprint command line tool `snowcrash` installed. 
+### Drafter
+In order for this plugin to work properly you need to have the API Blueprint command line tool `drafter` installed.
 
-To install `Snow Crash` on OS X using run the following command: 
+To install `Drafter` on OS X using run the following command:
+
 ```sh
 $ brew install --HEAD \
-  https://raw.github.com/apiaryio/snowcrash/master/tools/homebrew/snowcrash.rb
+  https://raw.github.com/apiaryio/drafter/master/tools/homebrew/drafter.rb
 ```
 
-Refer to [Snow Crash](https://github.com/apiaryio/snowcrash#install) installation notes for details on installing on [OS X & Linux](https://github.com/apiaryio/snowcrash#snow-crash-command-line-tool) or [Windows](https://github.com/apiaryio/snowcrash/wiki/Building-on-Windows).
+Refer to [Drafter](https://github.com/apiaryio/drafter#install) installation notes for details on installing on [OS X & Linux](https://github.com/apiaryio/drafter#drafter-command-line-tool) or [Windows](https://github.com/apiaryio/drafter/wiki/Building-on-Windows).
 
 ### SublimeLinter3 (optional)
 This plugin offers linting of your blueprints using the [SublimeLinter3](https://github.com/SublimeLinter/SublimeLinter3) plugin framework. In order for linting to work please [install](http://sublimelinter.readthedocs.org/en/latest/installation.html) `SublimeLinter3`.
@@ -34,7 +35,7 @@ With [Package Control](https://packagecontrol.io/installation):
 2. Restart SublimeText editor (if required)
 
 ### From the Source
-With `Snow Crash` [installed](#requirements) run the following command in your Sublime Text 3 packages directory:
+With `Drafter` [installed](#requirements) run the following command in your Sublime Text 3 packages directory:
 
 ```sh
 $ git clone https://github.com/apiaryio/api-blueprint-sublime-plugin.git  "API Blueprint"
@@ -50,11 +51,11 @@ Depending on your OS (and Sublime Text version) the packages directories are:
 You can access the commands either using the command palette (`CTRL+SHIFT+P` or `CMD+SHIFT+P`) or via shortcuts.
 
 ### Shortcuts
-- `ALT+SHIFT+B`: Parse the active file and open result [AST](https://github.com/apiaryio/snowcrash/wiki/API-Blueprint-AST-Media-Types) including any possible parser messages in a new tab.
+- `ALT+SHIFT+B`: Parse the active file and open result [AST](https://github.com/apiaryio/api-blueprint-ast#ast-description) including any possible parser messages in a new tab.
 
 ## Acknowledgements
-+ This plugin uses parts of [CoffeeScript Sublime Plugin](http://xavura.github.com/CoffeeScript-Sublime-Plugin). 
-+ Thanks to [@WMeldon](https://github.com/WMeldon) for his contribution. 
++ This plugin uses parts of [CoffeeScript Sublime Plugin](http://xavura.github.com/CoffeeScript-Sublime-Plugin).
++ Thanks to [@WMeldon](https://github.com/WMeldon) for his contribution.
 
 ## License
 MIT License. See the [LICENSE](LICENSE) file.

--- a/linter.py
+++ b/linter.py
@@ -19,8 +19,8 @@ def ApiBlueprintFactory():
         """Provides an interface to apiblueprint."""
 
         syntax = 'apiblueprint'
-        cmd = 'snowcrash --validate'
-        executable = 'snowcrash'
+        cmd = 'drafter --validate'
+        executable = 'drafter'
         executable = None
         regex = (
             r'(?:(?P<warning>warning)|(?P<error>error)):\s*\((?P<code>\d+)\)'


### PR DESCRIPTION
With the introduction of cli interface in drafter and removal of it from snowcrash, we need to change the sublime plugin.