### PR TITLE
Update API Blueprint specific syntax.

### DIFF
--- a/APIBlueprint.tmLanguage
+++ b/APIBlueprint.tmLanguage
@@ -1678,7 +1678,7 @@
     <key>blueprint_action</key>
     <dict>
       <key>match</key>
-      <string>^#{1,3} .*\[(HEAD|GET|PUT|POST|DELETE)\]\n?</string>
+      <string>^#{1,3} .*\[(HEAD|GET|PUT|POST|PATCH|DELETE)\]\n?</string>
       <key>name</key>
       <string>markup.heading.markdown</string>
       <key>captures</key>
@@ -1693,7 +1693,7 @@
     <key>blueprint_shorthand</key>
     <dict>
       <key>match</key>
-      <string>^# (HEAD|GET|PUT|POST|DELETE) (.*)\n?</string>
+      <string>^# (HEAD|GET|PUT|POST|PATCH|DELETE) (.*)\n?</string>
       <key>name</key>
       <string>markup.heading.markdown</string>
       <key>captures</key>

--- a/APIBlueprint.tmLanguage
+++ b/APIBlueprint.tmLanguage
@@ -101,6 +101,143 @@
     </dict>
 
     <dict>
+      <key>name</key>
+      <string>blueprint.response.json</string>
+      <key>begin</key>
+      <string>\+ (Request|Response) (\d+)? ?\(?(\(.*json\)?)</string>
+      <key>end</key>
+      <string>^(?=\S)</string>
+      <key>captures</key>
+      <dict>
+        <key>2</key>
+        <dict>
+          <key>name</key>
+          <string>constant.numeric</string>
+        </dict>
+        <key>3</key>
+        <dict>
+          <key>name</key>
+          <string>variable.language.fenced.markdown</string>
+        </dict>
+      </dict>
+      <key>patterns</key>
+      <array>
+        <dict>
+          <key>include</key>
+          <string>#http-headers</string>
+        </dict>
+        <dict>
+          <key>begin</key>
+          <string>\+ Body</string>
+          <key>end</key>
+          <string>^(?=(?=\S)|(?=\s+\+))</string>
+          <key>patterns</key>
+          <array>
+            <dict>
+              <key>include</key>
+              <string>source.js</string>
+            </dict>
+          </array>
+        </dict>
+        <dict>
+          <key>comment</key>
+          <string>Ignore list items that aren't the headers of body</string>
+          <key>begin</key>
+          <string>\+</string>
+          <key>end</key>
+          <string>^(?=(?=\S)|(?=\s+\+))</string>
+        </dict>
+        <dict>
+          <key>include</key>
+          <string>source.js</string>
+        </dict>
+      </array>
+    </dict>
+
+    <dict>
+      <key>name</key>
+      <string>blueprint.response.xml</string>
+      <key>begin</key>
+      <string>\+ (Request|Response) (\d+)? ?\(?(\(.*xml\)?)</string>
+      <key>end</key>
+      <string>^(?=\S)</string>
+      <key>captures</key>
+      <dict>
+        <key>2</key>
+        <dict>
+          <key>name</key>
+          <string>constant.numeric</string>
+        </dict>
+        <key>3</key>
+        <dict>
+          <key>name</key>
+          <string>variable.language.fenced.markdown</string>
+        </dict>
+      </dict>
+      <key>patterns</key>
+      <array>
+        <dict>
+          <key>include</key>
+          <string>#http-headers</string>
+        </dict>
+        <dict>
+          <key>begin</key>
+          <string>\+ Body</string>
+          <key>end</key>
+          <string>^(?=(?=\S)|(?=\s+\+))</string>
+          <key>patterns</key>
+          <array>
+            <dict>
+              <key>include</key>
+              <string>text.xml</string>
+            </dict>
+          </array>
+        </dict>
+        <dict>
+          <key>comment</key>
+          <string>Ignore list items that aren't the headers of body</string>
+          <key>begin</key>
+          <string>\+</string>
+          <key>end</key>
+          <string>^(?=(?=\S)|(?=\s+\+))</string>
+        </dict>
+        <dict>
+          <key>include</key>
+          <string>text.xml</string>
+        </dict>
+      </array>
+    </dict>
+
+    <dict>
+      <key>name</key>
+      <string>blueprint.response</string>
+      <key>begin</key>
+      <string>\+ (Request|Response) (\d+)? ?\(?(\(.*)\)?</string>
+      <key>end</key>
+      <string>^(?=\S)</string>
+      <key>captures</key>
+      <dict>
+        <key>2</key>
+        <dict>
+          <key>name</key>
+          <string>constant.numeric</string>
+        </dict>
+        <key>3</key>
+        <dict>
+          <key>name</key>
+          <string>variable.language.fenced.markdown</string>
+        </dict>
+      </dict>
+      <key>patterns</key>
+      <array>
+        <dict>
+          <key>include</key>
+          <string>#http-headers</string>
+        </dict>
+      </array>
+    </dict>
+
+    <dict>
       <key>begin</key>
       <string>(```|~~~)\s*(c)\s*$</string>
       <key>captures</key>
@@ -450,28 +587,6 @@
           <string>source.js</string>
         </dict>
       </array>
-    </dict>
-
-    <dict>
-      <key>captures</key>
-      <dict>
-        <key>2</key>
-        <dict>
-          <key>name</key>
-          <string>constant.numeric</string>
-        </dict>
-        <key>3</key>
-        <dict>
-          <key>name</key>
-          <string>variable.language.fenced.markdown</string>
-        </dict>
-      </dict>
-      <key>begin</key>
-      <string>\+ (Request|Response) (\d+)? ?\(?(.*)\)?</string>
-      <key>end</key>
-      <string>^(?=\S)</string>
-      <key>name</key>
-      <string>blueprint.response</string>
     </dict>
 
     <dict>
@@ -1755,6 +1870,33 @@
         <dict>
           <key>include</key>
           <string>#inline</string>
+        </dict>
+      </array>
+    </dict>
+    <key>http-headers</key>
+    <dict>
+      <key>begin</key>
+      <string>\+ Headers</string>
+      <key>end</key>
+      <string>^(?=(?=\S)|(?=\s+\+))</string>
+      <key>patterns</key>
+      <array>
+        <dict>
+          <key>match</key>
+          <string>(.*?):(.*)</string>
+          <key>captures</key>
+          <dict>
+            <key>1</key>
+            <dict>
+              <key>name</key>
+              <string>keyword</string>
+            </dict>
+            <key>2</key>
+            <dict>
+              <key>name</key>
+              <string>header-value</string>
+            </dict>
+          </dict>
         </dict>
       </array>
     </dict>

--- a/APIBlueprint.tmLanguage
+++ b/APIBlueprint.tmLanguage
@@ -75,6 +75,22 @@
         </dict>
         <dict>
           <key>include</key>
+          <string>#blueprint_group</string>
+        </dict>
+        <dict>
+          <key>include</key>
+          <string>#blueprint_action</string>
+        </dict>
+        <dict>
+          <key>include</key>
+          <string>#blueprint_resource</string>
+        </dict>
+        <dict>
+          <key>include</key>
+          <string>#blueprint_shorthand</string>
+        </dict>
+        <dict>
+          <key>include</key>
           <string>#heading</string>
         </dict>
         <dict>
@@ -434,6 +450,28 @@
           <string>source.js</string>
         </dict>
       </array>
+    </dict>
+
+    <dict>
+      <key>captures</key>
+      <dict>
+        <key>2</key>
+        <dict>
+          <key>name</key>
+          <string>constant.numeric</string>
+        </dict>
+        <key>3</key>
+        <dict>
+          <key>name</key>
+          <string>variable.language.fenced.markdown</string>
+        </dict>
+      </dict>
+      <key>begin</key>
+      <string>\+ (Request|Response) (\d+)? ?\(?(.*)\)?</string>
+      <key>end</key>
+      <string>^(?=\S)</string>
+      <key>name</key>
+      <string>blueprint.response</string>
     </dict>
 
     <dict>
@@ -1499,6 +1537,58 @@
       <string>\G([ ]{4}|\t).*$\n?</string>
       <key>name</key>
       <string>markup.raw.block.markdown</string>
+    </dict>
+    <key>blueprint_group</key>
+    <dict>
+      <key>match</key>
+      <string>^#{1,2} Group.*\n?</string>
+      <key>name</key>
+      <string>markup.heading.markdown</string>
+    </dict>
+    <key>blueprint_resource</key>
+    <dict>
+      <key>match</key>
+      <string>^#{1,2} .*\[(.*)\]\n?</string>
+      <key>name</key>
+      <string>markup.heading.markdown</string>
+      <key>captures</key>
+      <dict>
+        <key>1</key>
+        <dict>
+          <key>name</key>
+          <string>markup.underline</string>
+        </dict>
+      </dict>
+    </dict>
+    <key>blueprint_action</key>
+    <dict>
+      <key>match</key>
+      <string>^#{1,3} .*\[(HEAD|GET|PUT|POST|DELETE)\]\n?</string>
+      <key>name</key>
+      <string>markup.heading.markdown</string>
+      <key>captures</key>
+      <dict>
+        <key>1</key>
+        <dict>
+          <key>name</key>
+          <string>markup.quote</string>
+        </dict>
+      </dict>
+    </dict>
+    <key>blueprint_shorthand</key>
+    <dict>
+      <key>match</key>
+      <string>^# (HEAD|GET|PUT|POST|DELETE) (.*)\n?</string>
+      <key>name</key>
+      <string>markup.heading.markdown</string>
+      <key>captures</key>
+      <dict>
+        <key>2</key>
+        <dict>
+          <key>name</key>
+          <string>markup.underline</string>
+        </dict>
+      </dict>
     </dict>
     <key>bold</key>
     <dict>


### PR DESCRIPTION
Adds support for the following elements:

* Resource group `## Group <NAME>`
* Resource `## <NAME> [<URL>]`
* Resource actions `### <NAME> [<VERB>]`
* Blueprint shorthand `# <VERB> [<URL>]`
* Request/response code and type

Request/response bodies and headers are not yet highlighted in the correct
language. This may require a good bit more work to not match the `+ Body` part
while still matching the contents of the body and supporting the shorthand
where there is no explicit body list item.

This PR addresses some of the issues surfaced in #10.

Shorthand example:
![screen shot 2015-04-22 at 14 09 47](https://cloud.githubusercontent.com/assets/106826/7285437/6050de5c-e8f9-11e4-9ab7-9398e430177c.png)

Full example:
![screen shot 2015-04-22 at 14 09 56](https://cloud.githubusercontent.com/assets/106826/7285439/65871918-e8f9-11e4-8e1c-0da62a41280a.png)