### PR TITLE
Refract udpate

### DIFF
--- a/APIBlueprint.py
+++ b/APIBlueprint.py
@@ -7,53 +7,59 @@ from os import path
 from subprocess import Popen, PIPE
 from sublime_plugin import TextCommand, WindowCommand
 
+
 class Text():
-        @staticmethod
-        def all(view):
-                return view.substr(sublime.Region(0, view.size()))
-        @staticmethod
-        def sel(view):
-                text = []
-                for region in view.sel():
-                        if region.empty():
-                                continue
-                        text.append(view.substr(region))
-                return "".join(text)
 
-        @staticmethod
-        def get(view):
-                text = Text.sel(view)
-                if len(text) > 0:
-                        return text
-                return Text.all(view)
+    @staticmethod
+    def all(view):
+        return view.substr(sublime.Region(0, view.size()))
 
-def run_command(cmd, args = [], source = "", cwd = None, env = None):
-  settings = sublime.load_settings('APIBlueprint.sublime-settings')
+    @staticmethod
+    def sel(view):
+        text = []
+        for region in view.sel():
+            if region.empty():
+                continue
+            text.append(view.substr(region))
+        return "".join(text)
 
-  if not type(args) is list:
-    args = [args]
+    @staticmethod
+    def get(view):
+        text = Text.sel(view)
+        if len(text) > 0:
+            return text
+        return Text.all(view)
 
-  if env is None:
-    env = {"PATH": settings.get('binDir', '/usr/local/bin')}
 
-  command = [cmd] + args
+def run_command(cmd, args=[], source="", cwd=None, env=None):
+    settings = sublime.load_settings('APIBlueprint.sublime-settings')
 
-  proc = Popen(command, env = env, cwd = cwd, stdin = PIPE, stdout = PIPE, stderr = PIPE)
-  stat = proc.communicate(input=source.encode('utf-8'))
+    if not type(args) is list:
+        args = [args]
 
-  okay = proc.returncode == 0
+    if env is None:
+        env = {"PATH": settings.get('binDir', '/usr/local/bin')}
 
-  #remove leading empty line
-  lines = stat[1].decode('UTF-8').split('\n')
-  if not lines[0]:
-    lines.pop(0)
-  sanitized_errout = '\n'.join(lines)
+    command = [cmd] + args
 
-  return {"okay": okay, "out": stat[0].decode('UTF-8'), "err": sanitized_errout}
+    proc = Popen(command, env=env, cwd=cwd,
+                 stdin=PIPE, stdout=PIPE, stderr=PIPE)
+    stat = proc.communicate(input=source.encode('utf-8'))
+
+    okay = proc.returncode == 0
+
+    # remove leading empty line
+    lines = stat[1].decode('UTF-8').split('\n')
+    if not lines[0]:
+        lines.pop(0)
+    sanitized_errout = '\n'.join(lines)
+
+    return {"okay": okay, "out": stat[0].decode('UTF-8'), "err": sanitized_errout}
+
 
 def parse_buffer(view, args, edit):
     source = Text.all(view)
-    result = run_command("drafter", args = args, source = source)
+    result = run_command("drafter", args=args, source=source)
     body = result["err"] + '\n' + result["out"]
 
     output = view.window().new_file()
@@ -66,10 +72,14 @@ def parse_buffer(view, args, edit):
 
     output.insert(edit, 0, body)
 
+
 class ParseYamlAstCommand(TextCommand):
+
     def run(self, edit, **kwargs):
         parse_buffer(self.view, kwargs["opt"], edit)
 
+
 class ParseJsonAstCommand(TextCommand):
+
     def run(self, edit, **kwargs):
         parse_buffer(self.view, kwargs["opt"], edit)

--- a/APIBlueprint.sublime-commands
+++ b/APIBlueprint.sublime-commands
@@ -1,11 +1,11 @@
 [
   {
-    "caption": "API Blueprint: Parse to YAML Refract",
+    "caption": "API Blueprint: Parse to API Elements (YAML)",
     "command": "parse_yaml_ast",
     "args": {"opt": ["-f", "yaml"]}
   },
   {
-    "caption": "API Blueprint: Parse to JSON Refract",
+    "caption": "API Blueprint: Parse to API Elements (JSON)",
     "command": "parse_json_ast",
     "args": {"opt": ["-f", "json"]}
   }

--- a/APIBlueprint.sublime-commands
+++ b/APIBlueprint.sublime-commands
@@ -1,11 +1,11 @@
 [
   {
-    "caption": "API Blueprint: Parse to YAML AST",
+    "caption": "API Blueprint: Parse to YAML Refract",
     "command": "parse_yaml_ast",
     "args": {"opt": ["-f", "yaml"]}
   },
   {
-    "caption": "API Blueprint: Parse to JSON AST",
+    "caption": "API Blueprint: Parse to JSON Refract",
     "command": "parse_json_ast",
     "args": {"opt": ["-f", "json"]}
   }

--- a/linter.py
+++ b/linter.py
@@ -12,6 +12,7 @@
 
 """This module exports the Apiblueprint plugin class."""
 
+
 def ApiBlueprintFactory():
     """ Define API Blueprint Linter Class"""
 
@@ -50,11 +51,11 @@ def ApiBlueprintFactory():
                 line = int(line) - self.line_col_base[0]
 
             return match, line, col, error, warning, message, near
-            
+
 try:
     """Attempt to import SublimeLinter3"""
     from SublimeLinter.lint import Linter, util
     ApiBlueprintFactory()
-    
+
 except ImportError:
     print("No SublimeLinter3 installed - Install SublimeLinter3 to lint your API blueprints (ST3 Only)")


### PR DESCRIPTION
Update the plug-in to use the term `API Elements` instead of deprecated AST. 

As the latest Drafter uses API description refract namespace – [API Elements](https://github.com/refractproject/refract-spec/blob/master/namespaces/api-description-namespace.md)