### PR TITLE
Update Drafter installation method

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,7 @@ In order for this plugin to work properly you need to have the API Blueprint com
 To install `Drafter` on OS X using run the following command:
 
 ```sh
-$ brew install --HEAD \
-  https://raw.github.com/apiaryio/drafter/master/tools/homebrew/drafter.rb
+$ brew install drafter
 ```
 
 Refer to [Drafter](https://github.com/apiaryio/drafter#install) installation notes for details on installing on [OS X & Linux](https://github.com/apiaryio/drafter#drafter-command-line-tool) or [Windows](https://github.com/apiaryio/drafter/wiki/Building-on-Windows).


### PR DESCRIPTION
I noticed when installing this plug-in that Drafter is already in homebrew-core repository (since June 5th):

https://github.com/Homebrew/homebrew-core/pull/28667

Therefore running just simple `brew install` will do all the work.

Also, maybe the Ruby file could be removed from the Drafter repository as a next step.